### PR TITLE
Automatic AWS var setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ docker-compose up --build
 curl http://localhost:8080/health
 ```
 
+### Initialize env vars
+```bash
+source scripts/local-env-setup.sh
+```
+
 ### Verify DynamoDB tables:
 ```bash
 aws dynamodb list-tables \

--- a/scripts/local-env-setup.sh
+++ b/scripts/local-env-setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export AWS_ACCESS_KEY_ID=dummy
+export AWS_SECRET_ACCESS_KEY=dummy
+export AWS_DEFAULT_REGION=us-east-1
+


### PR DESCRIPTION
ONLY MERGE AFTER #6

Added script to set env vars in line with `docker-compose.yml` so that we don't have to add env vars every time (or worse, add the permanently since it's an arbitrary variable).

Also updated readme to reflect that extra step.