### PR TITLE
Logging

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"log"
+	"log/slog"
+	"os"
 	"wordle-tournament-backend/internal/config"
 	"wordle-tournament-backend/internal/server"
 )
 
 func main() {
 	cfg := config.Get()
+
+	// JSON logs above INFO level are sent to stderr
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	log.Printf("Starting Wordle Tournament API...")
 	log.Printf("Port: %s", cfg.Port)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"log"
 	"log/slog"
 	"os"
+	"wordle-tournament-backend/internal/common"
 	"wordle-tournament-backend/internal/config"
 	"wordle-tournament-backend/internal/server"
 )
@@ -14,13 +14,11 @@ func main() {
 	// JSON logs above INFO level are sent to stderr
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
-	log.Printf("Starting Wordle Tournament API...")
-	log.Printf("Port: %s", cfg.Port)
-
 	srv := server.New()
 
-	log.Printf("Server listening on :%s", cfg.Port)
+	common.LogInfo("main", "Wordle Tournament API listening on :"+cfg.Port)
 	if err := srv.Start(cfg.Port); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+		common.LogError("main", "Failed to start server", 500, slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -16,11 +16,20 @@ func main() {
 	// slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	// Text logs above INFO level are sent to stderr
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		// Drop slog's built-in empty message while preserving custom attrs (including msg).
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.MessageKey && a.Value.String() == "" {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})))
 
 	srv := server.New()
 
-	common.LogInfo("ServerStart", &common.LogData{Msg: "Listening on :" + cfg.Port})
+	common.LogInfo("ServerStart", &common.LogData{Msg: "Listening on Port " + cfg.Port})
 	if err := srv.Start(cfg.Port); err != nil {
 		common.LogError("ServerStartFailure", &common.LogData{Msg: err.Error()})
 		os.Exit(1)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,14 +11,18 @@ import (
 func main() {
 	cfg := config.Get()
 
+	// Uncomment this if we switch to json logs
 	// JSON logs above INFO level are sent to stderr
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	// slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	// Text logs above INFO level are sent to stderr
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
 
 	srv := server.New()
 
-	common.LogInfo("main", "Wordle Tournament API listening on :"+cfg.Port)
+	common.LogInfo("ServerStart", &common.LogData{Msg: "Listening on :" + cfg.Port})
 	if err := srv.Start(cfg.Port); err != nil {
-		common.LogError("main", "Failed to start server", 500, slog.String("error", err.Error()))
+		common.LogError("ServerStartFailure", &common.LogData{Msg: err.Error()})
 		os.Exit(1)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=dummy
       - AWS_REGION=us-east-1
     depends_on:
-      - setup-local-db
+      setup-local-db:
+        condition: service_completed_successfully
     ports:
       - "8080:8080"
 

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -12,7 +12,6 @@ import (
 // Difference between LogWarning and LogError is that LogWarnings result from malformed requests,
 // while LogErrors result from server errors.
 
-// LogInfo logs at Info level. Includes msg, endpoint, and any optional attrs (e.g. team_id, run_id).
 func LogInfo(endpoint string, msg string, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 2+len(attrs))
 	all = append(all, slog.String("msg", msg), slog.String("endpoint", endpoint))
@@ -20,7 +19,6 @@ func LogInfo(endpoint string, msg string, attrs ...slog.Attr) {
 	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, all...)
 }
 
-// LogWarning logs a client error (4xx) at Warn level. Includes msg, endpoint, status, and any optional attrs.
 func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 3+len(attrs))
 	all = append(all,
@@ -32,7 +30,6 @@ func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
 	slog.Default().LogAttrs(context.Background(), slog.LevelWarn, msg, all...)
 }
 
-// LogError logs a server error (5xx) at Error level. Includes msg, endpoint, status, and any optional attrs.
 func LogError(endpoint string, msg string, status int, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 3+len(attrs))
 	all = append(all,

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Justification for log.go in common:
+// - Though exclusively used in the handlers, doesn't make sense to scope it there.
+// - Reduce module bloat with another `logging` module
+
+// Difference between LogWarning and LogError is that LogWarnings result from malformed requests,
+// while LogErrors result from server errors.
+
+// LogInfo logs at Info level. Includes msg, endpoint, and any optional attrs (e.g. team_id, run_id).
+func LogInfo(endpoint string, msg string, attrs ...slog.Attr) {
+	all := make([]slog.Attr, 0, 2+len(attrs))
+	all = append(all, slog.String("msg", msg), slog.String("endpoint", endpoint))
+	all = append(all, attrs...)
+	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, all...)
+}
+
+// LogWarning logs a client error (4xx) at Warn level. Includes msg, endpoint, status, and any optional attrs.
+func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
+	all := make([]slog.Attr, 0, 3+len(attrs))
+	all = append(all,
+		slog.String("msg", msg),
+		slog.String("endpoint", endpoint),
+		slog.Int("status", status),
+	)
+	all = append(all, attrs...)
+	slog.Default().LogAttrs(context.Background(), slog.LevelWarn, msg, all...)
+}
+
+// LogError logs a server error (5xx) at Error level. Includes msg, endpoint, status, and any optional attrs.
+func LogError(endpoint string, msg string, status int, attrs ...slog.Attr) {
+	all := make([]slog.Attr, 0, 3+len(attrs))
+	all = append(all,
+		slog.String("msg", msg),
+		slog.String("endpoint", endpoint),
+		slog.Int("status", status),
+	)
+	all = append(all, attrs...)
+	slog.Default().LogAttrs(context.Background(), slog.LevelError, msg, all...)
+}

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -9,35 +9,37 @@ import (
 // - Though exclusively used in the handlers, doesn't make sense to scope it there.
 // - Reduce module bloat with another `logging` module
 
-// Difference between LogWarning and LogError is that LogWarnings result from malformed requests,
-// while LogErrors result from server errors.
-//
-// source is the HTTP endpoint (e.g. "start", "end") or the module (e.g. "main", "corpus").
-// For non-request logs, status can be 0 (or 500 for errors) to indicate N/A.
-
-func LogInfo(source string, msg string, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 1+len(attrs))
-	all = append(all, slog.String("source", source))
-	all = append(all, attrs...)
-	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, all...)
+type LogData struct {
+	TeamID string
+	RunID  string
+	Msg    string
 }
 
-func LogWarning(source string, msg string, status int, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 2+len(attrs))
-	all = append(all,
-		slog.String("source", source),
-		slog.Int("status", status),
-	)
-	all = append(all, attrs...)
-	slog.Default().LogAttrs(context.Background(), slog.LevelWarn, msg, all...)
+func LogInfo(name string, data *LogData) {
+	logWithLevel(slog.LevelInfo, name, data)
 }
 
-func LogError(source string, msg string, status int, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 2+len(attrs))
-	all = append(all,
-		slog.String("source", source),
-		slog.Int("status", status),
-	)
-	all = append(all, attrs...)
-	slog.Default().LogAttrs(context.Background(), slog.LevelError, msg, all...)
+func LogWarning(name string, data *LogData) {
+	logWithLevel(slog.LevelWarn, name, data)
+}
+
+func LogError(name string, data *LogData) {
+	logWithLevel(slog.LevelError, name, data)
+}
+
+func logWithLevel(level slog.Level, name string, data *LogData) {
+	attrs := []slog.Attr{slog.String("name", name)}
+	if data != nil {
+		if data.TeamID != "" {
+			attrs = append(attrs, slog.String("team_id", data.TeamID))
+		}
+		if data.RunID != "" {
+			attrs = append(attrs, slog.String("run_id", data.RunID))
+		}
+		if data.Msg != "" {
+			attrs = append(attrs, slog.String("msg", data.Msg))
+		}
+	}
+
+	slog.Default().LogAttrs(context.Background(), level, name, attrs...)
 }

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -41,5 +41,6 @@ func logWithLevel(level slog.Level, name string, data *LogData) {
 		}
 	}
 
-	slog.Default().LogAttrs(context.Background(), level, name, attrs...)
+	// Empty msg parameter to avoid automatic "msg=..." field in logs
+	slog.Default().LogAttrs(context.Background(), level, "", attrs...)
 }

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -13,16 +13,15 @@ import (
 // while LogErrors result from server errors.
 
 func LogInfo(endpoint string, msg string, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 2+len(attrs))
-	all = append(all, slog.String("msg", msg), slog.String("endpoint", endpoint))
+	all := make([]slog.Attr, 0, 1+len(attrs))
+	all = append(all, slog.String("endpoint", endpoint))
 	all = append(all, attrs...)
 	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, all...)
 }
 
 func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 3+len(attrs))
+	all := make([]slog.Attr, 0, 2+len(attrs))
 	all = append(all,
-		slog.String("msg", msg),
 		slog.String("endpoint", endpoint),
 		slog.Int("status", status),
 	)
@@ -31,9 +30,8 @@ func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
 }
 
 func LogError(endpoint string, msg string, status int, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, 3+len(attrs))
+	all := make([]slog.Attr, 0, 2+len(attrs))
 	all = append(all,
-		slog.String("msg", msg),
 		slog.String("endpoint", endpoint),
 		slog.Int("status", status),
 	)

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -11,28 +11,31 @@ import (
 
 // Difference between LogWarning and LogError is that LogWarnings result from malformed requests,
 // while LogErrors result from server errors.
+//
+// source is the HTTP endpoint (e.g. "start", "end") or the module (e.g. "main", "corpus").
+// For non-request logs, status can be 0 (or 500 for errors) to indicate N/A.
 
-func LogInfo(endpoint string, msg string, attrs ...slog.Attr) {
+func LogInfo(source string, msg string, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 1+len(attrs))
-	all = append(all, slog.String("endpoint", endpoint))
+	all = append(all, slog.String("source", source))
 	all = append(all, attrs...)
 	slog.Default().LogAttrs(context.Background(), slog.LevelInfo, msg, all...)
 }
 
-func LogWarning(endpoint string, msg string, status int, attrs ...slog.Attr) {
+func LogWarning(source string, msg string, status int, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 2+len(attrs))
 	all = append(all,
-		slog.String("endpoint", endpoint),
+		slog.String("source", source),
 		slog.Int("status", status),
 	)
 	all = append(all, attrs...)
 	slog.Default().LogAttrs(context.Background(), slog.LevelWarn, msg, all...)
 }
 
-func LogError(endpoint string, msg string, status int, attrs ...slog.Attr) {
+func LogError(source string, msg string, status int, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, 2+len(attrs))
 	all = append(all,
-		slog.String("endpoint", endpoint),
+		slog.String("source", source),
 		slog.Int("status", status),
 	)
 	all = append(all, attrs...)

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -90,7 +90,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 			LogWarning("EndInvalidIDs", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
-			LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("EndActiveRunNotFound", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return
@@ -145,7 +145,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 				CompletedRuns: []storage.CompletedRun{completedRun},
 			}
 		} else {
-			LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("EndScoreNotFound", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -155,14 +155,14 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 
 	// Update the Scores database with the new run history
 	if err := storage.PutScore(scoreItem); err != nil {
-		LogError("EndInternalError	", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogError("EndUpdateScoreFailure", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Remove the run from the ActiveRuns database
 	if err := storage.RemoveActiveRun(req.TeamID, req.RunID); err != nil {
-		LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogError("EndRemoveActiveRunFailure", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -72,7 +72,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	LogInfo("end", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+	LogInfo("end", "entered end handler", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 
 	// Query ActiveRuns database
 	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -3,11 +3,12 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
-	"wordle-tournament-backend/internal/common"
+	. "wordle-tournament-backend/internal/common"
 	"wordle-tournament-backend/internal/storage"
 	"wordle-tournament-backend/internal/wordle/corpus"
 )
@@ -54,19 +55,24 @@ func EndHandler() http.HandlerFunc {
 func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	var req EndRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		LogWarning("end", err.Error(), http.StatusBadRequest)
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if req.TeamID == "" {
+		LogWarning("end", errors.New("team_id cannot be empty").Error(), http.StatusBadRequest)
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
+		LogWarning("end", errors.New("run_id cannot be empty").Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID))
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
+
+	LogInfo("end", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 
 	// Query ActiveRuns database
 	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)
@@ -74,6 +80,13 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 		statusCode := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "expired or not found") {
 			statusCode = http.StatusBadRequest
+		}
+
+		// StatusCode < 500 differentiates between client and server errors
+		if statusCode < 500 {
+			LogWarning("end", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		} else {
+			LogError("end", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		}
 		http.Error(w, err.Error(), statusCode)
 		return
@@ -96,7 +109,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 
 	if allSolved {
 		score = calculateScore(activeRun.Games)
-		avg = totalGuesses / float64(common.NumTargetWords)
+		avg = totalGuesses / float64(NumTargetWords)
 		scorePtr = &score
 		avgPtr = &avg
 		solved = true
@@ -124,6 +137,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 				CompletedRuns: []storage.CompletedRun{completedRun},
 			}
 		} else {
+			LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -132,11 +146,13 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := storage.PutScore(scoreItem); err != nil {
+		LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	if err := storage.RemoveActiveRun(req.TeamID, req.RunID); err != nil {
+		LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -46,6 +46,7 @@ func EndHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostEnd(w, r)
 		default:
+			LogWarning("EndInvalidRequest", &LogData{Msg: "method not allowed"})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -69,13 +70,13 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.TeamID == "" {
-		LogWarning("EndInvalidRequest", &LogData{Msg: "empty team_id"})
+		LogWarning("EndEmptyTeamID", &LogData{})
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
-		LogWarning("EndInvalidRequest", &LogData{TeamID: req.TeamID, Msg: "empty run_id"})
+		LogWarning("EndEmptyRunID", &LogData{TeamID: req.TeamID})
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
@@ -90,7 +91,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 			LogWarning("EndInvalidIDs", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
-			LogError("EndActiveRunNotFound", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("EndGetActiveRunFailure", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return
@@ -145,7 +146,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 				CompletedRuns: []storage.CompletedRun{completedRun},
 			}
 		} else {
-			LogError("EndScoreNotFound", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("EndGetScoreFailure", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -51,6 +51,15 @@ func EndHandler() http.HandlerFunc {
 	}
 }
 
+// /api/end is hit once a run is complete.
+// This handler will:
+// 1. Validate the request
+// 2. Query the ActiveRuns database to get the run
+// 3. Confirm all games are solved
+// 4. Calculate the score and average guesses
+// 5. Update the Scores database
+// 6. Remove the run from the ActiveRuns database
+// 7. Return the response
 func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	var req EndRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -71,9 +80,9 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	LogInfo("EndProcessingRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID})
+	LogInfo("EndProcessRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID})
 
-	// Query ActiveRuns database
+	// Query ActiveRuns database for current run state (should've ended by now)
 	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)
 	if err != nil {
 		isClientError := strings.Contains(err.Error(), "expired or not found")
@@ -102,6 +111,8 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	var scorePtr, avgPtr *float64
 	var solved bool
 
+	// Calculate score and average guesses if all games are solved
+	// Otherwise, set score and average guesses to 0
 	if allSolved {
 		score = calculateScore(activeRun.Games)
 		avg = totalGuesses / float64(NumTargetWords)
@@ -124,6 +135,8 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 		CompletedAt:    time.Now(),
 	}
 
+	// Query Scores database for team's run history
+	// Add the completed run to the team's run history
 	scoreItem, err := storage.GetScore(req.TeamID)
 	if err != nil {
 		if errors.Is(err, storage.ErrScoreNotFound) {
@@ -132,7 +145,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 				CompletedRuns: []storage.CompletedRun{completedRun},
 			}
 		} else {
-			LogError("End", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -140,14 +153,16 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 		scoreItem.CompletedRuns = append(scoreItem.CompletedRuns, completedRun)
 	}
 
+	// Update the Scores database with the new run history
 	if err := storage.PutScore(scoreItem); err != nil {
-		LogError("end", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogError("EndInternalError	", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	// Remove the run from the ActiveRuns database
 	if err := storage.RemoveActiveRun(req.TeamID, req.RunID); err != nil {
-		LogError("end", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/end.go
+++ b/internal/handlers/end.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -55,40 +54,36 @@ func EndHandler() http.HandlerFunc {
 func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	var req EndRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		LogWarning("end", err.Error(), http.StatusBadRequest)
+		LogWarning("EndInvalidRequest", &LogData{Msg: err.Error()})
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if req.TeamID == "" {
-		LogWarning("end", errors.New("team_id cannot be empty").Error(), http.StatusBadRequest)
+		LogWarning("EndInvalidRequest", &LogData{Msg: "empty team_id"})
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
-		LogWarning("end", errors.New("run_id cannot be empty").Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID))
+		LogWarning("EndInvalidRequest", &LogData{TeamID: req.TeamID, Msg: "empty run_id"})
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	LogInfo("end", "entered end handler", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+	LogInfo("EndProcessingRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID})
 
 	// Query ActiveRuns database
 	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)
 	if err != nil {
-		statusCode := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "expired or not found") {
-			statusCode = http.StatusBadRequest
-		}
-
-		// StatusCode < 500 differentiates between client and server errors
-		if statusCode < 500 {
-			LogWarning("end", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		isClientError := strings.Contains(err.Error(), "expired or not found")
+		if isClientError {
+			LogWarning("EndInvalidIDs", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
-			LogError("end", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+			LogError("EndInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		http.Error(w, err.Error(), statusCode)
 		return
 	}
 
@@ -137,7 +132,7 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 				CompletedRuns: []storage.CompletedRun{completedRun},
 			}
 		} else {
-			LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+			LogError("End", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -146,13 +141,13 @@ func handlePostEnd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := storage.PutScore(scoreItem); err != nil {
-		LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		LogError("end", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	if err := storage.RemoveActiveRun(req.TeamID, req.RunID); err != nil {
-		LogError("end", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		LogError("end", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"strings"
 	"wordle-tournament-backend/internal/common"
@@ -28,7 +27,7 @@ func GuessesHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostGuesses(w, r)
 		default:
-			LogWarning("guesses", errors.New("method not allowed").Error(), http.StatusMethodNotAllowed)
+			LogWarning("guesses", &LogData{Msg: errors.New("method not allowed").Error()})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -41,27 +40,27 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 	// TODO: uppercase guesses will FAIL
 	var req GuessesRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		LogWarning("guesses", err.Error(), http.StatusBadRequest)
+		LogWarning("guesses", &LogData{Msg: err.Error()})
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if req.TeamID == "" {
-		LogWarning("guesses", errors.New("team_id cannot be empty").Error(), http.StatusBadRequest)
+		LogWarning("guesses", &LogData{Msg: errors.New("team_id cannot be empty").Error()})
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
-		LogWarning("guesses", errors.New("run_id cannot be empty").Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID))
+		LogWarning("guesses", &LogData{TeamID: req.TeamID, Msg: errors.New("run_id cannot be empty").Error()})
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	LogInfo("guesses", "entered guesses handler", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+	LogInfo("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: "entered guesses handler"})
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
-		LogWarning("guesses", err.Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		LogWarning("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -74,9 +73,9 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 			statusCode = http.StatusBadRequest
 		}
 		if statusCode < 500 {
-			LogWarning("guesses", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+			LogWarning("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		} else {
-			LogError("guesses", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+			LogError("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		}
 		http.Error(w, err.Error(), statusCode)
 		return
@@ -106,7 +105,7 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := storage.PutActiveRun(activeRun); err != nil {
-		LogError("guesses", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		LogError("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -11,8 +11,8 @@ import (
 )
 
 type GuessesRequest struct {
-	TeamId  string   `json:"team_id"`
-	RunId   string   `json:"run_id"`
+	TeamID  string   `json:"team_id"`
+	RunID   string   `json:"run_id"`
 	Guesses []string `json:"guesses"`
 }
 
@@ -42,24 +42,24 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.TeamId == "" {
+	if req.TeamID == "" {
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	if req.RunId == "" {
+	if req.RunID == "" {
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	log.Printf("guesses: TeamID=%s RunID=%s", req.TeamId, req.RunId)
+	log.Printf("guesses: TeamID=%s RunID=%s", req.TeamID, req.RunID)
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	activeRun, err := storage.GetActiveRun(req.TeamId, req.RunId)
+	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)
 	if err != nil {
 		// Must distinguish between (team_id, run_id) being invalid and network issues causing the request to fail.
 		statusCode := http.StatusInternalServerError

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -64,7 +64,7 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	LogInfo("GuessesProcessRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID})
+	LogInfo("GuessesProcessRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: "test message"})
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
 		LogWarning("GuessesInvalidGuesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"strings"
 	"wordle-tournament-backend/internal/common"
@@ -27,7 +26,7 @@ func GuessesHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostGuesses(w, r)
 		default:
-			LogWarning("guesses", &LogData{Msg: errors.New("method not allowed").Error()})
+			LogWarning("GuessesInvalidRequest", &LogData{Msg: "method not allowed"})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -36,48 +35,54 @@ func GuessesHandler() http.HandlerFunc {
 // Potential Issues:
 // - If the team_id + run_id are invalid, request returns 500 error when we should return something more helpful.
 // - No server-side validation on NumGuesses being less than MAX_GUESSSES (already in middleware)
+
+// /api/guesses is hit once a team wants to submit a guess.
+// This handler will:
+// 1. Validate the request
+// 2. Query the ActiveRuns database to get the run
+// 3. Grade the guesses
+// 4. Update the ActiveRuns database
+// 5. Return the response
 func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 	// TODO: uppercase guesses will FAIL
 	var req GuessesRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		LogWarning("guesses", &LogData{Msg: err.Error()})
+		LogWarning("GuessesInvalidRequest", &LogData{Msg: err.Error()})
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if req.TeamID == "" {
-		LogWarning("guesses", &LogData{Msg: errors.New("team_id cannot be empty").Error()})
+		LogWarning("GuessesEmptyTeamID", &LogData{})
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
-		LogWarning("guesses", &LogData{TeamID: req.TeamID, Msg: errors.New("run_id cannot be empty").Error()})
+		LogWarning("GuessesEmptyRunID", &LogData{TeamID: req.TeamID})
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	LogInfo("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: "entered guesses handler"})
+	LogInfo("GuessesProcessRequest", &LogData{TeamID: req.TeamID, RunID: req.RunID})
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
-		LogWarning("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogWarning("GuessesInvalidGuesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
+	// Query the ActiveRuns database to get the current run state
 	activeRun, err := storage.GetActiveRun(req.TeamID, req.RunID)
 	if err != nil {
-		// Must distinguish between (team_id, run_id) being invalid and network issues causing the request to fail.
-		statusCode := http.StatusInternalServerError
-		if strings.Contains(err.Error(), "expired or not found") {
-			statusCode = http.StatusBadRequest
-		}
-		if statusCode < 500 {
-			LogWarning("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		isClientError := strings.Contains(err.Error(), "expired or not found")
+		if isClientError {
+			LogWarning("GuessesInvalidIDs", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
-			LogError("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			LogError("GuessesInternalError", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		http.Error(w, err.Error(), statusCode)
 		return
 	}
 
@@ -87,6 +92,7 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		answers[i] = activeRun.Games[i].Answer
 	}
 
+	// Grade the guesses then update associated metadata (solved, num_guesses, etc)
 	hints := wordle.GradeGuesses(req.Guesses, answers)
 
 	for i, hint := range hints {
@@ -104,8 +110,9 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Update the ActiveRuns database with the new run state
 	if err := storage.PutActiveRun(activeRun); err != nil {
-		LogError("guesses", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
+		LogError("GuessesUpdateActiveRunFailure", &LogData{TeamID: req.TeamID, RunID: req.RunID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -58,7 +58,7 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	LogInfo("guesses", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+	LogInfo("guesses", "entered guesses handler", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
 		LogWarning("guesses", err.Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))

--- a/internal/handlers/guesses.go
+++ b/internal/handlers/guesses.go
@@ -2,10 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
-	"log"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"wordle-tournament-backend/internal/common"
+	. "wordle-tournament-backend/internal/common"
 	"wordle-tournament-backend/internal/storage"
 	"wordle-tournament-backend/internal/wordle"
 )
@@ -26,6 +28,7 @@ func GuessesHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostGuesses(w, r)
 		default:
+			LogWarning("guesses", errors.New("method not allowed").Error(), http.StatusMethodNotAllowed)
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -38,23 +41,27 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 	// TODO: uppercase guesses will FAIL
 	var req GuessesRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		LogWarning("guesses", err.Error(), http.StatusBadRequest)
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if req.TeamID == "" {
+		LogWarning("guesses", errors.New("team_id cannot be empty").Error(), http.StatusBadRequest)
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	if req.RunID == "" {
+		LogWarning("guesses", errors.New("run_id cannot be empty").Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID))
 		http.Error(w, "run_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	log.Printf("guesses: TeamID=%s RunID=%s", req.TeamID, req.RunID)
+	LogInfo("guesses", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 
 	if err := wordle.ValidateGuesses(req.Guesses); err != nil {
+		LogWarning("guesses", err.Error(), http.StatusBadRequest, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -65,6 +72,11 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 		statusCode := http.StatusInternalServerError
 		if strings.Contains(err.Error(), "expired or not found") {
 			statusCode = http.StatusBadRequest
+		}
+		if statusCode < 500 {
+			LogWarning("guesses", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
+		} else {
+			LogError("guesses", err.Error(), statusCode, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		}
 		http.Error(w, err.Error(), statusCode)
 		return
@@ -94,6 +106,7 @@ func handlePostGuesses(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := storage.PutActiveRun(activeRun); err != nil {
+		LogError("guesses", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", req.RunID))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
 
+	. "wordle-tournament-backend/internal/common"
 	"wordle-tournament-backend/internal/storage"
 	"wordle-tournament-backend/internal/wordle"
 )
@@ -24,6 +27,7 @@ func StartHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostStart(w, r)
 		default:
+			LogWarning("start", errors.New("method not allowed").Error(), http.StatusMethodNotAllowed)
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -32,16 +36,21 @@ func StartHandler() http.HandlerFunc {
 func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		LogWarning("start", err.Error(), http.StatusBadRequest)
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if err := wordle.ValidateTeamId(req.TeamID); err != nil {
+		LogWarning("start", err.Error(), http.StatusUnauthorized, slog.String("team_id", req.TeamID))
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+
 	runID := uuid.New().String()
+	LogInfo("start", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", runID))
 	if err := storage.PutDefaultActiveRun(req.TeamID, runID); err != nil {
+		LogError("start", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", runID))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -27,7 +26,7 @@ func StartHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostStart(w, r)
 		default:
-			LogWarning("start", errors.New("method not allowed").Error(), http.StatusMethodNotAllowed)
+			LogWarning("start", &LogData{Msg: errors.New("method not allowed").Error()})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -36,21 +35,21 @@ func StartHandler() http.HandlerFunc {
 func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		LogWarning("start", err.Error(), http.StatusBadRequest)
+		LogWarning("start", &LogData{Msg: err.Error()})
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
 	if err := wordle.ValidateTeamId(req.TeamID); err != nil {
-		LogWarning("start", err.Error(), http.StatusUnauthorized, slog.String("team_id", req.TeamID))
+		LogWarning("start", &LogData{TeamID: req.TeamID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
 	runID := uuid.New().String()
-	LogInfo("start", "entered start handler", slog.String("team_id", req.TeamID), slog.String("run_id", runID))
+	LogInfo("start", &LogData{TeamID: req.TeamID, RunID: runID, Msg: "entered start handler"})
 	if err := storage.PutDefaultActiveRun(req.TeamID, runID); err != nil {
-		LogError("start", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", runID))
+		LogError("start", &LogData{TeamID: req.TeamID, RunID: runID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -48,7 +48,7 @@ func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runID := uuid.New().String()
-	LogInfo("start", "entry", slog.String("team_id", req.TeamID), slog.String("run_id", runID))
+	LogInfo("start", "entered start handler", slog.String("team_id", req.TeamID), slog.String("run_id", runID))
 	if err := storage.PutDefaultActiveRun(req.TeamID, runID); err != nil {
 		LogError("start", err.Error(), http.StatusInternalServerError, slog.String("team_id", req.TeamID), slog.String("run_id", runID))
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -25,12 +24,17 @@ func StartHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostStart(w, r)
 		default:
-			LogWarning("StartInvalidRequest", &LogData{Msg: errors.New("method not allowed").Error()})
+			LogWarning("StartInvalidRequest", &LogData{Msg: "method not allowed"})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
 }
 
+// /api/start is hit once a team wants to start a new run.
+// This handler will:
+// 1. Validate the request
+// 2. Create a new active run for the team
+// 3. Return the response
 func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -40,7 +44,7 @@ func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.TeamID == "" {
-		LogWarning("StartInvalidRequest", &LogData{Msg: "empty team_id"})
+		LogWarning("StartEmptyTeamID", &LogData{})
 		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}

--- a/internal/handlers/start.go
+++ b/internal/handlers/start.go
@@ -9,7 +9,6 @@ import (
 
 	. "wordle-tournament-backend/internal/common"
 	"wordle-tournament-backend/internal/storage"
-	"wordle-tournament-backend/internal/wordle"
 )
 
 type StartRequest struct {
@@ -26,7 +25,7 @@ func StartHandler() http.HandlerFunc {
 		case http.MethodPost:
 			handlePostStart(w, r)
 		default:
-			LogWarning("start", &LogData{Msg: errors.New("method not allowed").Error()})
+			LogWarning("StartInvalidRequest", &LogData{Msg: errors.New("method not allowed").Error()})
 			http.Error(w, "HTTP Method not allowed", http.StatusMethodNotAllowed)
 		}
 	}
@@ -35,21 +34,23 @@ func StartHandler() http.HandlerFunc {
 func handlePostStart(w http.ResponseWriter, r *http.Request) {
 	var req StartRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		LogWarning("start", &LogData{Msg: err.Error()})
+		LogWarning("StartInvalidRequest", &LogData{Msg: err.Error()})
 		http.Error(w, "Invalid json body", http.StatusBadRequest)
 		return
 	}
 
-	if err := wordle.ValidateTeamId(req.TeamID); err != nil {
-		LogWarning("start", &LogData{TeamID: req.TeamID, Msg: err.Error()})
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+	if req.TeamID == "" {
+		LogWarning("StartInvalidRequest", &LogData{Msg: "empty team_id"})
+		http.Error(w, "team_id cannot be empty", http.StatusBadRequest)
 		return
 	}
 
 	runID := uuid.New().String()
-	LogInfo("start", &LogData{TeamID: req.TeamID, RunID: runID, Msg: "entered start handler"})
+	LogInfo("StartProcessRequest", &LogData{TeamID: req.TeamID, RunID: runID})
+
+	// Create a new active run for the team
 	if err := storage.PutDefaultActiveRun(req.TeamID, runID); err != nil {
-		LogError("start", &LogData{TeamID: req.TeamID, RunID: runID, Msg: err.Error()})
+		LogError("StartCreateActiveRunFailure", &LogData{TeamID: req.TeamID, RunID: runID, Msg: err.Error()})
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/integration_test/backend_test.go
+++ b/internal/integration_test/backend_test.go
@@ -105,8 +105,8 @@ func TestIntegrationInstantSolve(t *testing.T) {
 
 	// Step 4: Submit all perfect guesses via POST /api/guesses
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 
@@ -290,8 +290,8 @@ func TestIntegrationEndBeforeAllSolved(t *testing.T) {
 	}
 
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 
@@ -418,8 +418,8 @@ func TestIntegrationEndCalledTwice(t *testing.T) {
 
 	// Step 3: Submit all perfect guesses via POST /api/guesses to solve all games
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 
@@ -524,8 +524,8 @@ func TestIntegrationGuessesAfterEnd(t *testing.T) {
 
 	// Step 3: Submit all perfect guesses via POST /api/guesses to solve all games
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 
@@ -620,8 +620,8 @@ func TestIntegrationGuessesArrayLengthMismatch(t *testing.T) {
 	}
 
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 
@@ -693,8 +693,8 @@ func TestIntegrationMultipleGuessRounds(t *testing.T) {
 	}
 
 	guessesReq := handlers.GuessesRequest{
-		TeamId:  teamID,
-		RunId:   runID,
+		TeamID:  teamID,
+		RunID:   runID,
 		Guesses: guesses,
 	}
 

--- a/internal/wordle/corpus/corpus.go
+++ b/internal/wordle/corpus/corpus.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"encoding/csv"
 	"fmt"
-	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -56,7 +55,7 @@ func IsValidWord(word string) bool {
 func initializeCorpus() {
 	corpus = loadToSet(corpusData)
 	possibleAnswers = loadWeightedAnswers(answersCsvData)
-	common.LogInfo("corpus", fmt.Sprintf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers)))
+	common.LogInfo("corpus", &common.LogData{Msg: fmt.Sprintf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers))})
 }
 
 func loadToSet(data string) wordSet {
@@ -71,12 +70,12 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 	reader := csv.NewReader(strings.NewReader(csvData))
 	records, err := reader.ReadAll()
 	if err != nil {
-		common.LogError("corpus", "Failed to parse CSV", 0, slog.String("error", err.Error()))
+		common.LogError("corpus", &common.LogData{Msg: "Failed to parse CSV"})
 		os.Exit(1)
 	}
 
 	if len(records) == 0 {
-		common.LogError("corpus", "CSV file is empty", 0)
+		common.LogError("corpus", &common.LogData{Msg: "CSV file is empty"})
 		os.Exit(1)
 	}
 
@@ -94,7 +93,7 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 
 		weight, err := strconv.ParseFloat(weightStr, 64)
 		if err != nil {
-			common.LogWarning("corpus", "failed to parse weight for word", 0, slog.String("word", word), slog.String("error", err.Error()))
+			common.LogWarning("corpus", &common.LogData{Msg: "failed to parse weight for word"})
 			continue
 		}
 

--- a/internal/wordle/corpus/corpus.go
+++ b/internal/wordle/corpus/corpus.go
@@ -55,7 +55,7 @@ func IsValidWord(word string) bool {
 func initializeCorpus() {
 	corpus = loadToSet(corpusData)
 	possibleAnswers = loadWeightedAnswers(answersCsvData)
-	common.LogInfo("corpus", &common.LogData{Msg: fmt.Sprintf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers))})
+	common.LogInfo("CorpusLoadSuccess", &common.LogData{Msg: fmt.Sprintf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers))})
 }
 
 func loadToSet(data string) wordSet {
@@ -70,12 +70,12 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 	reader := csv.NewReader(strings.NewReader(csvData))
 	records, err := reader.ReadAll()
 	if err != nil {
-		common.LogError("corpus", &common.LogData{Msg: "Failed to parse CSV"})
+		common.LogError("CorpusParseCSVFailure", &common.LogData{Msg: "Failed to parse CSV"})
 		os.Exit(1)
 	}
 
 	if len(records) == 0 {
-		common.LogError("corpus", &common.LogData{Msg: "CSV file is empty"})
+		common.LogError("CorpusEmptyCSVFile", &common.LogData{Msg: "CSV file is empty"})
 		os.Exit(1)
 	}
 

--- a/internal/wordle/corpus/corpus.go
+++ b/internal/wordle/corpus/corpus.go
@@ -93,7 +93,7 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 
 		weight, err := strconv.ParseFloat(weightStr, 64)
 		if err != nil {
-			common.LogWarning("corpus", &common.LogData{Msg: "failed to parse weight for word"})
+			common.LogWarning("CorpusParseWeightFailure", &common.LogData{Msg: "failed to parse weight for word " + word})
 			continue
 		}
 

--- a/internal/wordle/corpus/corpus.go
+++ b/internal/wordle/corpus/corpus.go
@@ -3,10 +3,14 @@ package corpus
 import (
 	_ "embed"
 	"encoding/csv"
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
+
+	"wordle-tournament-backend/internal/common"
 )
 
 type wordSet map[string]struct{}
@@ -52,7 +56,7 @@ func IsValidWord(word string) bool {
 func initializeCorpus() {
 	corpus = loadToSet(corpusData)
 	possibleAnswers = loadWeightedAnswers(answersCsvData)
-	log.Printf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers))
+	common.LogInfo("corpus", fmt.Sprintf("Loaded %d words from corpus and %d possible answers with weights", len(corpus), len(possibleAnswers)))
 }
 
 func loadToSet(data string) wordSet {
@@ -67,11 +71,13 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 	reader := csv.NewReader(strings.NewReader(csvData))
 	records, err := reader.ReadAll()
 	if err != nil {
-		log.Fatalf("Failed to parse CSV: %v", err)
+		common.LogError("corpus", "Failed to parse CSV", 0, slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 
 	if len(records) == 0 {
-		log.Fatal("CSV file is empty")
+		common.LogError("corpus", "CSV file is empty", 0)
+		os.Exit(1)
 	}
 
 	// Skip header row
@@ -88,7 +94,7 @@ func loadWeightedAnswers(csvData string) answerWeightsMap {
 
 		weight, err := strconv.ParseFloat(weightStr, 64)
 		if err != nil {
-			log.Printf("Warning: failed to parse weight for word %s: %v", word, err)
+			common.LogWarning("corpus", "failed to parse weight for word", 0, slog.String("word", word), slog.String("error", err.Error()))
 			continue
 		}
 


### PR DESCRIPTION

<img width="956" height="402" alt="Screenshot 2026-03-06 at 7 53 14 PM" src="https://github.com/user-attachments/assets/259ab687-3e86-4c9f-bea4-4380509048b2" />

Every log now has a name and "msg" is an optional parameter. Compare GuessesProcessRequest to EndProcessRequest to verify that msg isn't always printed.

Go's server code doesn't automatically log if we return an error, so it would be helpful for us to handle logging.

Currently we log on entry to every endpoint (in case we need to track execution) resulting in way too many logs. Before we deploy, we can remove INFO logs altogether? 